### PR TITLE
fix(uml-chat): include engineType when editing and resending messages

### DIFF
--- a/src/tools/ui/webviewHtmlGenerator.ts
+++ b/src/tools/ui/webviewHtmlGenerator.ts
@@ -5262,11 +5262,16 @@ export class WebviewHtmlGenerator {
                             const diagramTypeSelect = document.getElementById('diagramType');
                             const selectedDiagramType = diagramTypeSelect ? diagramTypeSelect.value : '';
                             
+                            // Get the current engine type selection
+                            const engineTypeSelect = document.getElementById('engineType');
+                            const selectedEngineType = engineTypeSelect ? engineTypeSelect.value : 'plantuml';
+                            
                             vscode.postMessage({ 
                                 command: 'editAndResendUserMsg', 
                                 index: idx, 
                                 newText: newText,
-                                diagramType: selectedDiagramType
+                                diagramType: selectedDiagramType,
+                                engineType: selectedEngineType
                             });
                         }
                     };

--- a/src/tools/umlChatPanel.ts
+++ b/src/tools/umlChatPanel.ts
@@ -1880,7 +1880,21 @@ function getWebviewContent(chatHistory: { role: 'user' | 'bot', message: string 
                     saveBtn.onclick = function() {
                         const newText = textarea.value.trim();
                         if (newText) {
-                            vscode.postMessage({ command: 'editAndResendUserMsg', index: idx, newText: newText });
+                            // Get the current diagram type selection
+                            const diagramTypeSelect = document.getElementById('diagramType');
+                            const selectedDiagramType = diagramTypeSelect ? diagramTypeSelect.value : '';
+                            
+                            // Get the current engine type selection
+                            const engineTypeSelect = document.getElementById('engineType');
+                            const selectedEngineType = engineTypeSelect ? engineTypeSelect.value : 'plantuml';
+                            
+                            vscode.postMessage({ 
+                                command: 'editAndResendUserMsg', 
+                                index: idx, 
+                                newText: newText,
+                                diagramType: selectedDiagramType,
+                                engineType: selectedEngineType
+                            });
                         }
                     };
                     


### PR DESCRIPTION
- Modified webview HTML generator to capture selected engineType from dropdown
- Updated both umlChatPanel.ts and webviewHtmlGenerator.ts for consistency
- Now when user changes engine and edits a message, the new engine will be applied

Fixes the issue where engine selection wasn't being applied during edit/resend operations